### PR TITLE
Project Info Support

### DIFF
--- a/app/blog/[post]/page.js
+++ b/app/blog/[post]/page.js
@@ -44,7 +44,21 @@ export default async function Page({ params }) {
       <header className="flex flex-col gap-2">
         <h1 className="font-semibold text-4xl">{post[0].title}</h1>
         <p className="font-medium text-lg">{post[0].description}</p>
-        <div className="flex items-center gap-2 my-4 text-olive-300">
+        {post[0].tags && (
+          <div className="flex items-center gap-2">
+            {post[0].tags.map((tag, index) => (
+              <a
+                key={index}
+                href={`/blog?tag=${tag}`}
+                className="inline-flex items-center gap-2 text-olive-50 bg-olive-700 px-3 py-1 rounded-full"
+              >
+                <Tag className="w-5 h-5" />
+                {tag}
+              </a>
+            ))}
+          </div>
+        )}
+        <div className="flex items-center gap-2 text-olive-300">
           <Calendar className="w-5 h-5" />
           <span className="font-mono">{post[0].date}</span>
           <div />
@@ -52,18 +66,6 @@ export default async function Page({ params }) {
           <span>
             {post[0].readTime || 1} {"min read"}
           </span>
-        </div>
-        <div className="flex items-center gap-2">
-          {post[0].tags &&
-            post[0].tags.map((tag, index) => (
-              <span
-                key={index}
-                className="inline-flex items-center gap-2 bg-olive-700 px-3 py-1 rounded-full"
-              >
-                <Tag className="w-5 h-5" />
-                {tag}
-              </span>
-            ))}
         </div>
       </header>
       <Image

--- a/app/blog/[post]/page.js
+++ b/app/blog/[post]/page.js
@@ -75,7 +75,7 @@ export default async function Page({ params }) {
         alt={post[0].title}
         className="w-full object-cover rounded-lg shadow-lg border-2 border-olive-50"
       />
-      <article className="prose prose-invert md:prose-lg mx-auto">
+      <article className="prose prose-invert md:prose-lg">
         <PortableText
           value={post[0].content}
           components={portableTextComponents}

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -2,6 +2,7 @@ import { client } from "/sanity/lib/client";
 import Container from "@/components/Container";
 import BlogCard from "@/components/Blog";
 import { Tag, X } from "lucide-react";
+import { filterByTag, orderByDate } from "@/utils";
 
 export const metadata = {
   title: "Bill Yu - Blog",
@@ -31,12 +32,11 @@ export default async function Page({ searchParams }) {
       </div>
       {/* TODO: Add option to sort by date */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {(searchParams["tag"]
-          ? posts.filter((e) => e.tags?.includes(searchParams["tag"]))
-          : posts
-        ).map((post, index) => (
-          <BlogCard post={post} key={index} index={index} />
-        ))}
+        {orderByDate(filterByTag(posts, searchParams["tag"])).map(
+          (post, index) => (
+            <BlogCard post={post} key={index} index={index} />
+          ),
+        )}
       </div>
     </Container>
   );

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -3,7 +3,7 @@ import Container from "@/components/Container";
 import BlogCard from "@/components/Blog";
 
 export const metadata = {
-  title: "Bill Yu | Blog",
+  title: "Bill Yu - Blog",
   description: "Read about my ideas on web development",
 };
 

--- a/app/blog/page.js
+++ b/app/blog/page.js
@@ -1,13 +1,14 @@
 import { client } from "/sanity/lib/client";
 import Container from "@/components/Container";
 import BlogCard from "@/components/Blog";
+import { Tag, X } from "lucide-react";
 
 export const metadata = {
   title: "Bill Yu - Blog",
   description: "Read about my ideas on web development",
 };
 
-export default async function Page() {
+export default async function Page({ searchParams }) {
   const posts = await getBlogPosts();
 
   return (
@@ -15,10 +16,25 @@ export default async function Page() {
       <div className="flex flex-col gap-2">
         <p className="text-4xl font-bold">Blog Articles</p>
         <p className="text-lg text-olive-300">Insights on Web Development</p>
+        <span
+          className={searchParams["tag"] ? "flex items-center gap-1" : "hidden"}
+        >
+          <p>Filter:</p>
+          <p className="inline-flex items-center gap-2 bg-olive-700 px-3 py-1 rounded-full">
+            <Tag className="w-5 h-5" />
+            {searchParams[Object.keys(searchParams)[0]]}
+          </p>
+          <a href="/blog">
+            <X />
+          </a>
+        </span>
       </div>
       {/* TODO: Add option to sort by date */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {posts.map((post, index) => (
+        {(searchParams["tag"]
+          ? posts.filter((e) => e.tags?.includes(searchParams["tag"]))
+          : posts
+        ).map((post, index) => (
           <BlogCard post={post} key={index} index={index} />
         ))}
       </div>

--- a/app/components/Highlights.js
+++ b/app/components/Highlights.js
@@ -6,18 +6,21 @@ const highlights = [
     title: "Medical Education Platform",
     description:
       "Currently developing a case-based learning platform to transform education for professors and students alike.",
+    link: "/projects/rxpert",
   },
   {
     icon: Globe,
     title: "Student Organization Website",
     description:
       "Initiate site for student organization offering free websites to local businesses through student volunteers.",
+    link: "/projects/web-impact",
   },
   {
     icon: Tractor,
     title: "BIPOC Urban Farm Website",
     description:
       "Piloted a team of developers to create an interactive website for a local urban farm, improving its online presence.",
+    link: "/projects/percussion-farms",
   },
 ];
 
@@ -36,7 +39,7 @@ export default function Highlights() {
             <highlight.icon className="w-12 h-12 mb-4 text-olive-300" />
             <h3 className="text-xl font-bold mb-2">{highlight.title}</h3>
             <p className="mb-4">{highlight.description}</p>
-            <a href="#" className="text-olive-300 hover:underline">
+            <a href={highlight.link} className="text-olive-300 hover:underline">
               Read More
             </a>
           </div>

--- a/app/components/Introduction.js
+++ b/app/components/Introduction.js
@@ -108,7 +108,7 @@ export default function Introduction() {
             seamless user experiences. My journey in web development is driven
             by a constant desire to learn and innovate.
           </p>
-          <div className="w-32 h-1 bg-olive-300"></div>
+          <div className="w-48 h-1 bg-olive-300"></div>
         </div>
       </div>
     </section>

--- a/app/components/Project.js
+++ b/app/components/Project.js
@@ -24,9 +24,9 @@ export default function ProjectCard({ project, index }) {
           alt={project.title}
           className="w-full h-64 md:h-96 object-cover rounded-lg shadow-lg"
         />
-        <div className="group absolute inset-0 bg-olive-300 bg-opacity-0 hover:bg-opacity-20 transition-all duration-300 rounded-lg flex items-center justify-center">
+        <div className="group absolute inset-0 bg-olive-300 bg-opacity-0 md:hover:bg-opacity-20 transition-all duration-300 rounded-lg flex items-center justify-center">
           <Link href={`/projects/${project.slug}`}>
-            <ArrowUpRight className="w-12 h-12 opacity-0 group-hover:opacity-100 transition-opacity duration-300 cursor-pointer" />
+            <ArrowUpRight className="w-12 h-12 opacity-0 md:group-hover:opacity-100 transition-opacity duration-300 cursor-pointer" />
           </Link>
         </div>
       </div>

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -2,7 +2,7 @@ import Container from "@/components/Container";
 import Form from "@/components/Form";
 
 export const metadata = {
-  title: "Bill Yu | Contact",
+  title: "Bill Yu - Contact",
   description: "Send me a message!",
 };
 

--- a/app/experience/page.js
+++ b/app/experience/page.js
@@ -3,7 +3,7 @@ import Container from "@/components/Container";
 import Experience from "@/components/Experience";
 
 export const metadata = {
-  title: "Bill Yu | Experience",
+  title: "Bill Yu - Experience",
   description: "Learn about my journey",
 };
 

--- a/app/projects/[project]/page.js
+++ b/app/projects/[project]/page.js
@@ -78,7 +78,7 @@ export default async function Page({ params }) {
       </div>
       <span className="flex items-end gap-1">
         <p>See it in action:</p>
-        <a className="underline text-lg" href={project[0].link}>
+        <a target="_blank" className="underline text-lg" href={project[0].link}>
           {project[0].link}
         </a>
       </span>

--- a/app/projects/[project]/page.js
+++ b/app/projects/[project]/page.js
@@ -4,7 +4,7 @@ import { urlForImage } from "/sanity/lib/image";
 import { tryGetImageDimensions } from "@sanity/asset-utils";
 import Image from "next/image";
 import Container from "@/components/Container";
-import { ArrowLeft, Calendar } from "lucide-react";
+import { ArrowLeft, Calendar, Tag } from "lucide-react";
 import Link from "next/link";
 
 const portableTextComponents = {
@@ -44,6 +44,20 @@ export default async function Page({ params }) {
       <header className="flex flex-col gap-2">
         <h1 className="font-semibold text-4xl">{project[0].title}</h1>
         <p className="font-medium text-lg">{project[0].description}</p>
+        {project[0].tags && (
+          <div className="flex items-center gap-2">
+            {project[0].tags.map((tag, index) => (
+              <a
+                key={index}
+                href={`/projects?tag=${tag}`}
+                className="inline-flex items-center gap-2 bg-olive-700 px-3 py-1 rounded-full"
+              >
+                <Tag className="w-5 h-5" />
+                {tag}
+              </a>
+            ))}
+          </div>
+        )}
         <div className="flex text-olive-300">
           <Calendar className="w-5 h-5 mr-2" />
           <span className="font-mono">{project[0].date}</span>
@@ -62,6 +76,12 @@ export default async function Page({ params }) {
           className="w-full object-cover rounded-lg shadow-lg"
         />
       </div>
+      <span className="flex items-end gap-1">
+        <p>See it in action:</p>
+        <a className="underline text-lg" href={project[0].link}>
+          {project[0].link}
+        </a>
+      </span>
       <hr className="border-olive-300" />
       <article className="prose prose-invert md:prose-lg mx-auto">
         <PortableText

--- a/app/projects/[project]/page.js
+++ b/app/projects/[project]/page.js
@@ -79,6 +79,8 @@ async function getProject(slug) {
     description,
     date,
     'slug': slug.current,
+    tags,
+    link,
     image,
     content
   }`;

--- a/app/projects/[project]/page.js
+++ b/app/projects/[project]/page.js
@@ -83,7 +83,7 @@ export default async function Page({ params }) {
         </a>
       </span>
       <hr className="border-olive-300" />
-      <article className="prose prose-invert md:prose-lg mx-auto">
+      <article className="prose prose-invert md:prose-lg">
         <PortableText
           value={project[0].content}
           components={portableTextComponents}

--- a/app/projects/page.js
+++ b/app/projects/page.js
@@ -32,6 +32,7 @@ async function getProjects() {
     description,
     date,
     'slug':slug.current,
+    tags,
     image
   }`;
 

--- a/app/projects/page.js
+++ b/app/projects/page.js
@@ -1,6 +1,7 @@
 import { client } from "/sanity/lib/client";
 import Container from "@/components/Container";
 import ProjectCard from "@/components/Project";
+import { filterByTag, orderByDate } from "@/utils";
 import { Tag, X } from "lucide-react";
 
 export const metadata = {
@@ -31,12 +32,11 @@ export default async function Page({ searchParams }) {
       </div>
       <hr className="text-olive-300 h-4" />
       <div className="space-y-12">
-        {(searchParams["tag"]
-          ? projects.filter((e) => e.tags?.includes(searchParams["tag"]))
-          : projects
-        ).map((project, index) => (
-          <ProjectCard project={project} key={index} index={index} />
-        ))}
+        {orderByDate(filterByTag(projects, searchParams["tag"])).map(
+          (project, index) => (
+            <ProjectCard project={project} key={index} index={index} />
+          ),
+        )}
       </div>
     </Container>
   );

--- a/app/projects/page.js
+++ b/app/projects/page.js
@@ -1,24 +1,40 @@
 import { client } from "/sanity/lib/client";
 import Container from "@/components/Container";
 import ProjectCard from "@/components/Project";
+import { Tag, X } from "lucide-react";
 
 export const metadata = {
   title: "Bill Yu - Projects",
   description: "Check out my cool projects!",
 };
 
-export default async function Page() {
+export default async function Page({ searchParams }) {
   const projects = await getProjects();
 
   return (
     <Container>
-      <div className="flex flex-col gap-2 text-center">
+      <div className="flex flex-col gap-2 items-center">
         <p className="text-4xl font-bold">My Projects</p>
         <p className="text-lg text-olive-300">Bringing Ideas to Life</p>
+        <span
+          className={searchParams["tag"] ? "flex items-center gap-1" : "hidden"}
+        >
+          <p>Filter:</p>
+          <p className="inline-flex items-center gap-2 bg-olive-700 px-3 py-1 rounded-full">
+            <Tag className="w-5 h-5" />
+            {searchParams[Object.keys(searchParams)[0]]}
+          </p>
+          <a href="/projects">
+            <X />
+          </a>
+        </span>
       </div>
       <hr className="text-olive-300 h-4" />
       <div className="space-y-12">
-        {projects.map((project, index) => (
+        {(searchParams["tag"]
+          ? projects.filter((e) => e.tags?.includes(searchParams["tag"]))
+          : projects
+        ).map((project, index) => (
           <ProjectCard project={project} key={index} index={index} />
         ))}
       </div>

--- a/app/projects/page.js
+++ b/app/projects/page.js
@@ -3,7 +3,7 @@ import Container from "@/components/Container";
 import ProjectCard from "@/components/Project";
 
 export const metadata = {
-  title: "Bill Yu | Project",
+  title: "Bill Yu - Projects",
   description: "Check out my cool projects!",
 };
 

--- a/app/utils.js
+++ b/app/utils.js
@@ -1,0 +1,7 @@
+export function orderByDate(values) {
+  return values.sort((a, b) => new Date(b.date) - new Date(a.date));
+}
+
+export function filterByTag(values, tag) {
+  return tag ? values.filter((e) => e.tags?.includes(tag)) : values;
+}

--- a/sanity/schema/documents/blogPost.js
+++ b/sanity/schema/documents/blogPost.js
@@ -45,6 +45,7 @@ export default {
       title: "Tags",
       type: "array",
       of: [{ type: "string" }],
+      validation: (Rule) => Rule.required(),
     },
     {
       name: "content",

--- a/sanity/schema/documents/project.js
+++ b/sanity/schema/documents/project.js
@@ -20,6 +20,19 @@ export default {
       },
     },
     {
+      name: "link",
+      title: "Link",
+      type: "text",
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: "tags",
+      title: "Tags",
+      type: "array",
+      of: [{ type: "string" }],
+      validation: (Rule) => Rule.required(),
+    },    
+    {
       name: "description",
       title: "Description",
       type: "text",

--- a/sanity/schema/documents/project.js
+++ b/sanity/schema/documents/project.js
@@ -30,7 +30,7 @@ export default {
       type: "array",
       of: [{ type: "string" }],
       validation: (Rule) => Rule.required(),
-    },    
+    },
     {
       name: "description",
       title: "Description",

--- a/sanity/schema/documents/project.js
+++ b/sanity/schema/documents/project.js
@@ -22,7 +22,8 @@ export default {
     {
       name: "link",
       title: "Link",
-      type: "text",
+      type: "string",
+      validation: (Rule) => Rule.required(),
     },
     {
       name: "tags",

--- a/sanity/schema/documents/project.js
+++ b/sanity/schema/documents/project.js
@@ -23,7 +23,6 @@ export default {
       name: "link",
       title: "Link",
       type: "text",
-      validation: (Rule) => Rule.required(),
     },
     {
       name: "tags",


### PR DESCRIPTION
## Project Info Support

Adds support for more detailed project information, specifically `link` and `tags`. 

### Link Support

Adds a required `link` string field to the schema. This is rendered as a navigation link below each project preview image. 

### Tag Support

Adds a required `tags` array field to the schema. This is rendered as a list of tags at each project header. These changes are also reflected for blogposts, which previously did not require tags. 

Tags for projects/blogposts are links to the projects/blog page (respectively) that apply a filter to that specific tag. This is made available through the `searchParam` parameter for each page. 

### Other Changes

* Add date sorting to both blogposts and projects
* Changed page metadata to use `-` instead of `|`
* Made project and blog content left-justified